### PR TITLE
docs: fix production-ready Markdown bold rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## 🏗️ 生产级实战
 
-**如果你想看如何在生产环境中使用本框架, 构建大型应用(包含: 全局状态, 数据库集成, 文件上传, JWT鉴权, WebSocket机制应用, CRUD组合器等), 请参考作者的完全体项目模版: **
+**如果你想看如何在生产环境中使用本框架, 构建大型应用(包含: 全局状态, 数据库集成, 文件上传, JWT鉴权, WebSocket机制应用, CRUD组合器等), 请参考作者的完全体项目模版:**
 
 👉 **[lsby/playground-ts-service](https://github.com/lsby/playground-ts-service)**
 


### PR DESCRIPTION
fix before
<img width="978" height="288" alt="image" src="https://github.com/user-attachments/assets/4b1d4a8d-d2d8-47df-8c92-76507598172b" />

fix after
<img width="1063" height="216" alt="image" src="https://github.com/user-attachments/assets/bcb12bf0-d92b-4526-b569-2a4e861a4cba" />

